### PR TITLE
v2.5.1 Updates dependencies

### DIFF
--- a/lib/trusona/version.rb
+++ b/lib/trusona/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trusona
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 end

--- a/trusona.gemspec
+++ b/trusona.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'guard-rubocop', '~> 1.3'
   spec.add_development_dependency 'guard-yard', '~> 2.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-wait', '~> 0.0'
   spec.add_development_dependency 'rubocop', '~> 0.49'


### PR DESCRIPTION
- Bumps Rake to v12.3.3 for CVE-2020-8130